### PR TITLE
Fix `ramp -> constant` task behaviour

### DIFF
--- a/src/tomato_jumo/__init__.py
+++ b/src/tomato_jumo/__init__.py
@@ -216,6 +216,8 @@ class Device(ModelDevice):
             self.ramp_task = Thread(target=self._temperature_ramp, daemon=True)
             self.ramp_task.do_run = True
             self.ramp_task.start()
+        elif isinstance(self.ramp_task, Thread) and self.ramp_task is True:
+            self.ramp_task.do_run = False
 
     def stop_task(self, **kwargs: dict) -> None:
         super().stop_task(self, **kwargs)


### PR DESCRIPTION
- When a `task` is instructed to stop, stop the ramp thread.
- When a component is instructed to reset, stop the ramp thread.
- When a new `task` is submitted, stop the ramp thread.